### PR TITLE
fixed issue of package not installing on linux

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "autoload": {
         "classmap": [
-            "src\\"
+            "src"
         ],
         "psr-4": {
-            "\\Coderatio\\Curler\\": "src"
+            "Coderatio\\Curler\\": "src"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
fixed issue of package not installing on linux with below error:

In ClassMapGenerator.php line 69: Could not scan for classes inside "/var/www/html/DeliverlySock/vendor/coderatio/curler/src\" which does not appear to be a file not a folder